### PR TITLE
refactor: migrate from callbacks to promises in background script

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,36 +1,34 @@
-import type { Alarm } from "./lib/types";
+import type { Alarm } from './lib/types';
+import { loadAlarms, saveAlarms } from './lib/storage';
 
 // Listen for alarm events
-chrome.alarms.onAlarm.addListener((alarm: chrome.alarms.Alarm) => {
+chrome.alarms.onAlarm.addListener(async (alarm: chrome.alarms.Alarm) => {
   console.log('Alarm triggered:', alarm.name);
 
   // The alarm name might be composite (e.g., "alarmId_day")
   const alarmId = alarm.name.split('_')[0];
 
-  chrome.storage.local.get('alarms', (result) => {
-    const alarms: Alarm[] = result.alarms || [];
-    const triggeredAlarm = alarms.find(a => a.id === alarmId);
+  const alarms = await loadAlarms();
+  const triggeredAlarm = alarms.find(a => a.id === alarmId);
 
-    const notificationOptions = {
-      type: 'basic' as const,
-      priority: 2,
-      iconUrl: chrome.runtime.getURL('src/icons/icon128.png'),
-      title: triggeredAlarm?.name || chrome.i18n.getMessage('alarm'),
-      message: triggeredAlarm?.description || chrome.i18n.getMessage('defaultAlarmMessage'),
-    };
+  const notificationOptions = {
+    type: 'basic' as const,
+    priority: 2,
+    iconUrl: chrome.runtime.getURL('src/icons/icon128.png'),
+    title: triggeredAlarm?.name || chrome.i18n.getMessage('alarm'),
+    message: triggeredAlarm?.description || chrome.i18n.getMessage('defaultAlarmMessage'),
+  };
 
-    chrome.notifications.create(alarm.name, notificationOptions, (notificationId) => {
-      if (chrome.runtime.lastError) {
-        console.error('Error creating notification:', chrome.runtime.lastError);
-      } else {
-        console.log('Notification created with ID:', notificationId);
-      }
-    });
+  try {
+    const notificationId = await chrome.notifications.create(alarm.name, notificationOptions);
+    console.log('Notification created with ID:', notificationId);
+  } catch (error) {
+    console.error('Error creating notification:', error);
+  }
 
-    // If it's a non-recurring alarm, disable it after it rings
-    if (triggeredAlarm && triggeredAlarm.days.length === 0) {
-      triggeredAlarm.enabled = false;
-      chrome.storage.local.set({ alarms });
-    }
-  });
+  // If it's a non-recurring alarm, disable it after it rings
+  if (triggeredAlarm && triggeredAlarm.days.length === 0) {
+    triggeredAlarm.enabled = false;
+    await saveAlarms(alarms);
+  }
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,3 @@
-import type { Alarm } from './lib/types';
 import { loadAlarms, saveAlarms } from './lib/storage';
 
 // Listen for alarm events


### PR DESCRIPTION
Refactored the `chrome.alarms.onAlarm` listener in `src/background.ts` to use `async/await` and promises instead of callbacks.

- Replaced `chrome.storage.local.get` and `chrome.storage.local.set` with promise-based `loadAlarms` and `saveAlarms` functions.
- Updated `chrome.notifications.create` to use promises.
- Updated tests in `src/background.test.ts` to align with the new promise-based implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized background script and its tests to use async/await patterns for improved clarity and consistency.
  * Simplified and updated mocking of Chrome APIs in tests for better reliability and readability.

* **Tests**
  * Updated test suite to handle asynchronous alarm listeners and streamline verification of notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->