### PR TITLE
Feat: Replace alarm notifications with standalone popup windows

### DIFF
--- a/src/alarm.html
+++ b/src/alarm.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Alarm</title>
+  <link rel="stylesheet" type="text/css" href="styles.css">
+</head>
+<body>
+  <div id="alarm-view">
+    <div class="header">
+      <h1 id="alarm-title">Alarm Ringing</h1>
+    </div>
+    <div class="alarm-content">
+      <div class="alarm-detail">
+        <strong>Name:</strong>
+        <span id="alarm-name-display" data-testid="alarm-name"></span>
+      </div>
+      <div class="alarm-detail">
+        <strong>Description:</strong>
+        <span id="alarm-description-display" data-testid="alarm-description"></span>
+      </div>
+    </div>
+    <div class="footer">
+      <button id="snooze-btn">Snooze (5 min)</button>
+      <button id="close-btn">Close</button>
+    </div>
+  </div>
+  <script type="module" src="alarm.ts"></script>
+</body>
+</html>

--- a/src/alarm.test.ts
+++ b/src/alarm.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { setupAlarmPage } from './alarm';
+
+vi.mock('./lib/storage', () => ({
+    loadTheme: vi.fn().mockResolvedValue('dark'),
+}));
+
+describe('Alarm Popup UI and Interactions', () => {
+    const setupDOM = (searchParams: URLSearchParams) => {
+        const html = fs.readFileSync(path.resolve(__dirname, 'alarm.html'), 'utf8');
+        document.body.innerHTML = html;
+        Object.defineProperty(window, 'location', {
+            value: { search: searchParams.toString() },
+            writable: true
+        });
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Object.defineProperty(window, 'close', { value: vi.fn(), writable: true });
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: vi.fn().mockImplementation(query => ({
+                matches: false,
+                media: query,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            })),
+        });
+    });
+
+    it('should display alarm name and description', async () => {
+        const params = new URLSearchParams('name=Test+Alarm&description=Test+Desc');
+        setupDOM(params);
+
+        setupAlarmPage();
+        await vi.dynamicImportSettled();
+
+        const alarmName = document.getElementById('alarm-name-display');
+        const alarmDescription = document.getElementById('alarm-description-display');
+        expect(alarmName?.textContent).toBe('Test Alarm');
+        expect(alarmDescription?.textContent).toBe('Test Desc');
+    });
+
+    it('should apply light theme from storage', async () => {
+        setupDOM(new URLSearchParams());
+        vi.mocked(chrome.storage.local.get).mockResolvedValue({ theme: 'light' });
+
+        setupAlarmPage();
+        await vi.dynamicImportSettled();
+
+        expect(document.body.classList.contains('light-theme')).toBe(true);
+    });
+
+    it('should send disable message for non-recurring alarm on close', async () => {
+        const params = new URLSearchParams('alarmName=alarm1&days=[]');
+        setupDOM(params);
+
+        setupAlarmPage();
+        await vi.dynamicImportSettled();
+
+        const closeBtn = document.getElementById('close-btn');
+        closeBtn?.click();
+        await new Promise(resolve => setTimeout(resolve, 0)); // Allow async event handler to complete
+
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'DISABLE_ALARM',
+                alarmName: 'alarm1'
+            }),
+            expect.any(Function)
+        );
+        expect(window.close).toHaveBeenCalledOnce();
+    });
+
+    it('should NOT send disable message for recurring alarm on close', async () => {
+        const params = new URLSearchParams('alarmName=alarm2&days=[1,2]');
+        setupDOM(params);
+
+        setupAlarmPage();
+        await vi.dynamicImportSettled();
+
+        const closeBtn = document.getElementById('close-btn');
+        closeBtn?.click();
+        await new Promise(resolve => setTimeout(resolve, 0)); // Allow async event handler to complete
+
+        expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+        expect(window.close).toHaveBeenCalledOnce();
+    });
+
+    it('should send disable message for non-recurring alarm on snooze', async () => {
+        const params = new URLSearchParams('alarmName=alarm1&days=[]');
+        setupDOM(params);
+
+        setupAlarmPage();
+        await vi.dynamicImportSettled();
+
+        const snoozeBtn = document.getElementById('snooze-btn');
+        snoozeBtn?.click();
+        await new Promise(resolve => setTimeout(resolve, 0)); // Allow async event handler to complete
+
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'DISABLE_ALARM',
+                alarmName: 'alarm1'
+            }),
+            expect.any(Function)
+        );
+        expect(chrome.alarms.create).toHaveBeenCalledOnce();
+        expect(window.close).toHaveBeenCalledOnce();
+    });
+});

--- a/src/alarm.ts
+++ b/src/alarm.ts
@@ -1,0 +1,92 @@
+// --- Theme ---
+const applyTheme = (theme: string) => {
+  if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      document.body.classList.toggle('light-theme', systemTheme === 'light');
+  } else {
+      document.body.classList.toggle('light-theme', theme === 'light');
+  }
+};
+
+const loadTheme = async () => {
+  try {
+    const result = await chrome.storage.local.get('theme');
+    const theme = result.theme || 'dark'; // Default to dark theme
+    applyTheme(theme);
+  } catch (e) {
+    console.error("Error loading theme:", e);
+    applyTheme('dark'); // Fallback to dark theme on error
+  }
+};
+
+// --- Interaction Logic ---
+const handleAlarmInteraction = async () => {
+    const params = new URLSearchParams(window.location.search);
+    const daysParam = params.get('days');
+    const alarmNameToDisable = params.get('alarmName');
+
+    if (daysParam && alarmNameToDisable) {
+        try {
+            const days = JSON.parse(daysParam);
+            if (Array.isArray(days) && days.length === 0) {
+                // This is a non-recurring alarm, so disable it by sending a message
+                // to the background script.
+                await new Promise(resolve => {
+                    chrome.runtime.sendMessage({
+                        type: 'DISABLE_ALARM',
+                        alarmName: alarmNameToDisable
+                    }, response => {
+                        // Even if the response fails, resolve the promise to close the window.
+                        // The background script will log the error.
+                        resolve(response);
+                    });
+                });
+            }
+        } catch (e) {
+            console.error("Error parsing 'days' parameter:", e);
+        }
+    }
+};
+
+export function setupAlarmPage() {
+  loadTheme();
+
+  // --- Alarm Details ---
+  const params = new URLSearchParams(window.location.search);
+  const alarmName = params.get('name');
+  const alarmDescription = params.get('description');
+
+  const alarmNameDisplay = document.getElementById('alarm-name-display');
+  if (alarmNameDisplay) {
+    alarmNameDisplay.textContent = alarmName || 'N/A';
+  }
+
+  const alarmDescriptionDisplay = document.getElementById('alarm-description-display');
+  if (alarmDescriptionDisplay) {
+    alarmDescriptionDisplay.textContent = alarmDescription || 'N/A';
+  }
+
+  // --- Buttons ---
+  const closeButton = document.getElementById('close-btn');
+  if (closeButton) {
+    closeButton.addEventListener('click', async () => {
+      await handleAlarmInteraction();
+      window.close();
+    });
+  }
+
+  const snoozeButton = document.getElementById('snooze-btn');
+  if (snoozeButton) {
+    snoozeButton.addEventListener('click', async () => {
+      await handleAlarmInteraction();
+      const originalAlarmName = params.get('alarmName');
+      if (originalAlarmName) {
+        const snoozeAlarmName = `snooze_${originalAlarmName}_${Date.now()}`;
+        chrome.alarms.create(snoozeAlarmName, { delayInMinutes: 5 });
+      }
+      window.close();
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', setupAlarmPage);

--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -1,115 +1,103 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
 import type { Alarm } from './lib/types';
+import * as storage from './lib/storage';
 
-type AlarmListener = (alarm: chrome.alarms.Alarm) => void;
+vi.mock('./lib/storage');
+
+type AlarmListener = (alarm: chrome.alarms.Alarm) => Promise<void>;
+type MessageListener = (message: any, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void) => void;
 
 describe('Background Script', () => {
   let onAlarmListener: AlarmListener;
+  let onMessageListener: MessageListener;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
 
-    // Spy on addListener to capture the callback
-    const addListenerSpy = vi.spyOn(chrome.alarms.onAlarm, 'addListener');
+    const onAlarmSpy = vi.spyOn(chrome.alarms.onAlarm, 'addListener');
+    const onMessageSpy = vi.spyOn(chrome.runtime.onMessage, 'addListener');
 
-    // Import the background script to execute its top-level code
     await import('./background');
 
-    // Capture the listener function
-    onAlarmListener = addListenerSpy.mock.calls[0][0];
+    onAlarmListener = onAlarmSpy.mock.calls[0][0];
+    onMessageListener = onMessageSpy.mock.calls[0][0];
   });
 
-  it('should register an onAlarm listener', () => {
-    expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalledOnce();
-    expect(onAlarmListener).toBeInstanceOf(Function);
-  });
-
-  it('should show a notification for a recurring alarm', async () => {
-    const mockChromeAlarm = { name: 'alarm1', scheduledTime: Date.now() };
-    const mockRecurringAlarm: Alarm = {
-      id: 'alarm1',
-      name: 'Test Recurring Alarm',
-      description: 'A test description',
-      time: '10:00',
-      days: [1, 2, 3], // Recurring
-      enabled: true,
-    };
-
-    // Setup mock for chrome.storage.local.get to return the alarm
-    vi.mocked(chrome.storage.local.get).mockImplementation((_keys, callback) => {
-      callback({ alarms: [mockRecurringAlarm] });
+  describe('onAlarm Listener', () => {
+    it('should register an onAlarm listener', () => {
+      expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalledOnce();
+      expect(onAlarmListener).toBeInstanceOf(Function);
     });
 
-    // Trigger the alarm listener
-    onAlarmListener(mockChromeAlarm);
+    it('should open a popup and pass correct URL params', async () => {
+      const mockChromeAlarm = { name: 'alarm1_123', scheduledTime: Date.now() };
+      const mockRecurringAlarm: Alarm = {
+        id: 'alarm1',
+        name: 'Test Alarm',
+        description: 'Test Desc',
+        time: '10:00',
+        days: [1, 2],
+        enabled: true,
+      };
+      vi.mocked(storage.loadAlarms).mockResolvedValue([mockRecurringAlarm]);
 
-    // Wait for async operations within the listener to complete
-    await vi.dynamicImportSettled();
+      await onAlarmListener(mockChromeAlarm);
 
-    // Verify notification was created with correct details
-    expect(chrome.notifications.create).toHaveBeenCalledOnce();
-    expect(chrome.notifications.create).toHaveBeenCalledWith(
-      mockChromeAlarm.name,
-      expect.objectContaining({
-        title: mockRecurringAlarm.name,
-        message: mockRecurringAlarm.description,
-      }),
-      expect.any(Function) // The callback function
-    );
-
-    // Verify storage.local.set was NOT called
-    expect(chrome.storage.local.set).not.toHaveBeenCalled();
-  });
-
-  it('should show a notification and disable a non-recurring alarm', async () => {
-    const mockChromeAlarm = { name: 'alarm2', scheduledTime: Date.now() };
-    const mockNonRecurringAlarm: Alarm = {
-      id: 'alarm2',
-      name: 'Test Non-Recurring Alarm',
-      description: 'A one-time alert',
-      time: '11:00',
-      days: [], // Non-recurring
-      enabled: true,
-    };
-
-    vi.mocked(chrome.storage.local.get).mockImplementation((_keys, callback) => {
-      callback({ alarms: [mockNonRecurringAlarm] });
+      expect(chrome.windows.create).toHaveBeenCalledOnce();
+      const createCall = vi.mocked(chrome.windows.create).mock.calls[0][0];
+      const url = new URL(createCall.url as string);
+      expect(url.searchParams.get('name')).toBe('Test Alarm');
+      expect(url.searchParams.get('description')).toBe('Test Desc');
+      expect(url.searchParams.get('alarmName')).toBe('alarm1_123');
+      expect(url.searchParams.get('days')).toBe('[1,2]');
     });
 
-    onAlarmListener(mockChromeAlarm);
-    await vi.dynamicImportSettled();
+    it('should NOT disable a one-time alarm immediately', async () => {
+        const mockChromeAlarm = { name: 'alarm2', scheduledTime: Date.now() };
+        const mockNonRecurringAlarm: Alarm = {
+          id: 'alarm2', name: 'Test', description: '', time: '11:00', days: [], enabled: true,
+        };
+        vi.mocked(storage.loadAlarms).mockResolvedValue([mockNonRecurringAlarm]);
 
-    expect(chrome.notifications.create).toHaveBeenCalledOnce();
+        await onAlarmListener(mockChromeAlarm);
 
-    // Verify storage.local.set was called to disable the alarm
-    expect(chrome.storage.local.set).toHaveBeenCalledOnce();
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({
-      alarms: [expect.objectContaining({ id: 'alarm2', enabled: false })],
+        expect(chrome.windows.create).toHaveBeenCalledOnce();
+        expect(storage.saveAlarms).not.toHaveBeenCalled();
     });
   });
 
-  it('should show a default notification if alarm is not found in storage', async () => {
-    const mockChromeAlarm = { name: 'alarm3', scheduledTime: Date.now() };
-
-    // Setup mock for chrome.storage.local.get to return no alarms
-    vi.mocked(chrome.storage.local.get).mockImplementation((_keys, callback) => {
-      callback({ alarms: [] });
+  describe('onMessage Listener', () => {
+    it('should register an onMessage listener', () => {
+        expect(chrome.runtime.onMessage.addListener).toHaveBeenCalledOnce();
+        expect(onMessageListener).toBeInstanceOf(Function);
     });
 
-    onAlarmListener(mockChromeAlarm);
-    await vi.dynamicImportSettled();
+    it('should disable a one-time alarm on DISABLE_ALARM message', async () => {
+      const mockAlarmToDisable: Alarm = {
+        id: 'alarm1', name: 'Test', description: '', time: '10:00', days: [], enabled: true,
+      };
+      vi.mocked(storage.loadAlarms).mockResolvedValue([mockAlarmToDisable]);
+      const message = { type: 'DISABLE_ALARM', alarmName: 'alarm1_123' };
 
-    // Verify notification was created with default details
-    expect(chrome.notifications.create).toHaveBeenCalledOnce();
-    expect(chrome.notifications.create).toHaveBeenCalledWith(
-      mockChromeAlarm.name,
-      expect.objectContaining({
-        title: 'alarm', // from i18n mock
-        message: 'defaultAlarmMessage', // from i18n mock
-      }),
-      expect.any(Function)
-    );
+      onMessageListener(message, {} as any, () => {});
+
+      // Allow async operations within the listener to complete
+      await vi.dynamicImportSettled();
+
+      expect(storage.loadAlarms).toHaveBeenCalledOnce();
+      expect(storage.saveAlarms).toHaveBeenCalledOnce();
+      expect(storage.saveAlarms).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'alarm1', enabled: false })
+      ]);
+    });
+
+    it('should not do anything for other messages', async () => {
+        const message = { type: 'UNKNOWN_MESSAGE' };
+        onMessageListener(message, {} as any, () => {});
+        await vi.dynamicImportSettled();
+        expect(storage.loadAlarms).not.toHaveBeenCalled();
+        expect(storage.saveAlarms).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,36 +1,101 @@
-import type { Alarm } from "./lib/types";
+import { loadAlarms, saveAlarms } from './lib/storage';
 
 // Listen for alarm events
-chrome.alarms.onAlarm.addListener((alarm: chrome.alarms.Alarm) => {
+chrome.alarms.onAlarm.addListener(async (alarm: chrome.alarms.Alarm) => {
   console.log('Alarm triggered:', alarm.name);
 
-  // The alarm name might be composite (e.g., "alarmId_day")
-  const alarmId = alarm.name.split('_')[0];
+  const alarms = await loadAlarms();
 
-  chrome.storage.local.get('alarms', (result) => {
-    const alarms: Alarm[] = result.alarms || [];
-    const triggeredAlarm = alarms.find(a => a.id === alarmId);
+  // For non-recurring alarms, the alarm name is the alarm ID.
+  // For recurring alarms, the name is `alarm.id + '_' + day`.
+  let triggeredAlarm = alarms.find(a => a.id === alarm.name);
 
-    const notificationOptions = {
-      type: 'basic' as const,
-      priority: 2,
-      iconUrl: chrome.runtime.getURL('src/icons/icon128.png'),
-      title: triggeredAlarm?.name || chrome.i18n.getMessage('alarm'),
-      message: triggeredAlarm?.description || chrome.i18n.getMessage('defaultAlarmMessage'),
+  if (!triggeredAlarm) {
+    // If not found, it might be a recurring alarm. Let's parse the ID.
+    const parts = alarm.name.split('_');
+    if (parts.length > 1) {
+      parts.pop(); // Remove the day part
+      const alarmId = parts.join('_');
+      triggeredAlarm = alarms.find(a => a.id === alarmId);
+    }
+  }
+
+  console.log('Found triggered alarm from storage:', triggeredAlarm);
+
+  const alarmName = triggeredAlarm?.name || chrome.i18n.getMessage('alarm');
+  const alarmDescription =
+    triggeredAlarm?.description ||
+    chrome.i18n.getMessage('defaultAlarmMessage');
+
+  // Create a popup window instead of a notification
+  const popupUrl = new URL(chrome.runtime.getURL('src/alarm.html'));
+  popupUrl.searchParams.append('name', alarmName);
+  popupUrl.searchParams.append('description', alarmDescription);
+  popupUrl.searchParams.append('alarmName', alarm.name);
+  const days = triggeredAlarm?.days || [];
+  popupUrl.searchParams.append('days', JSON.stringify(days));
+
+  // Get screen dimensions to center the popup
+  const displayInfo = await chrome.system.display.getInfo();
+  const primaryDisplay = displayInfo.find((d) => d.isPrimary) || displayInfo[0];
+  const screenWidth = primaryDisplay.workArea.width;
+  const screenHeight = primaryDisplay.workArea.height;
+  const width = 400;
+  const height = 250;
+
+  const left = Math.round((screenWidth - width) / 2);
+  const top = Math.round((screenHeight - height) / 2);
+
+  try {
+    await chrome.windows.create({
+      url: popupUrl.href,
+      type: 'popup',
+      width: width,
+      height: height,
+      left: left,
+      top: top,
+    });
+    console.log('Alarm window created for:', alarm.name);
+  } catch (error) {
+    console.error('Error creating alarm window:', error);
+  }
+
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'DISABLE_ALARM') {
+    const disableAlarm = async () => {
+      try {
+        const alarms = await loadAlarms();
+        const alarmName = message.alarmName;
+
+        // For non-recurring alarms, the alarm name is the alarm ID.
+        // For recurring alarms, the name is `alarm.id + '_' + day`.
+        let alarmToDisable = alarms.find(a => a.id === alarmName);
+
+        if (!alarmToDisable) {
+          // If not found, it might be a recurring alarm. Let's parse the ID.
+          const parts = alarmName.split('_');
+          if (parts.length > 1) {
+            parts.pop(); // Remove the day part
+            const alarmId = parts.join('_');
+            alarmToDisable = alarms.find(a => a.id === alarmId);
+          }
+        }
+
+        if (alarmToDisable) {
+          alarmToDisable.enabled = false;
+          await saveAlarms(alarms);
+          console.log(`Disabled alarm: ${alarmToDisable.name}`);
+        }
+        sendResponse({ success: true });
+      } catch (error) {
+        console.error('Error disabling alarm:', error);
+        sendResponse({ success: false, error: (error as Error).message });
+      }
     };
 
-    chrome.notifications.create(alarm.name, notificationOptions, (notificationId) => {
-      if (chrome.runtime.lastError) {
-        console.error('Error creating notification:', chrome.runtime.lastError);
-      } else {
-        console.log('Notification created with ID:', notificationId);
-      }
-    });
-
-    // If it's a non-recurring alarm, disable it after it rings
-    if (triggeredAlarm && triggeredAlarm.days.length === 0) {
-      triggeredAlarm.enabled = false;
-      chrome.storage.local.set({ alarms });
-    }
-  });
+    disableAlarm();
+    return true; // Indicates that the response is sent asynchronously
+  }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   "permissions": [
     "alarms",
     "storage",
-    "notifications"
+    "system.display"
   ],
   "action": {
     "default_popup": "src/popup.html",
@@ -28,6 +28,7 @@
   "web_accessible_resources": [
     {
       "resources": [
+        "src/alarm.html",
         "src/icons/icon16.png",
         "src/icons/icon48.png",
         "src/icons/icon128.png"

--- a/src/styles.css
+++ b/src/styles.css
@@ -345,3 +345,52 @@ body.light-theme {
 body.light-theme .icon-btn:hover {
   background-color: rgba(0, 0, 0, 0.1);
 }
+
+/* Alarm View */
+#alarm-view {
+  padding: 0 16px 16px 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100vh; /* Make sure it fills the popup height */
+}
+
+#alarm-view .alarm-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+#alarm-view .header {
+  padding: 16px 0; /* Adjust padding for the new layout */
+  justify-content: center;
+}
+
+#alarm-view .footer {
+  display: flex;
+  justify-content: space-around;
+  gap: 16px;
+}
+
+#alarm-view .footer button {
+  flex-grow: 1;
+  padding: 12px;
+  font-size: 1em;
+  border-radius: 4px;
+  border: 1px solid var(--disabled-color);
+  background-color: var(--surface-color);
+  color: var(--on-surface-color);
+  cursor: pointer;
+}
+
+#alarm-view .footer button:hover {
+  border-color: var(--on-surface-color);
+}
+
+#alarm-view .footer button#snooze-btn {
+  background-color: var(--primary-color);
+  color: var(--on-primary-color);
+  border-color: var(--primary-color);
+}

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -43,8 +43,35 @@ const mockNotifications = {
 };
 
 const mockRuntime = {
-  getURL: (path: string) => path,
+  getURL: (path: string) => `chrome-extension://test-id/${path}`,
   lastError: undefined,
+  onMessage: {
+    addListener: vi.fn(),
+  },
+  sendMessage: vi.fn((message, callback) => {
+    if (callback) {
+      callback({ success: true });
+    }
+    return Promise.resolve({ success: true });
+  }),
+};
+
+const mockWindows = {
+  create: vi.fn(),
+};
+
+const mockSystem = {
+  display: {
+    getInfo: vi.fn().mockResolvedValue([
+      {
+        isPrimary: true,
+        workArea: {
+          width: 1920,
+          height: 1080,
+        },
+      },
+    ]),
+  },
 };
 
 // Mock the global chrome object
@@ -54,6 +81,8 @@ const chromeMock = {
   i18n: mockI18n,
   notifications: mockNotifications,
   runtime: mockRuntime,
+  windows: mockWindows,
+  system: mockSystem,
 };
 
 // Assign the mock to the global object

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,24 +1,18 @@
 import { defineConfig } from 'vite'
 import { crx } from '@crxjs/vite-plugin'
 import manifest from './src/manifest.json' with { type: 'json' }
+import { resolve } from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     crx({ manifest }),
   ],
+  build: {
+    rollupOptions: {
+      input: {
+        alarm: resolve(__dirname, 'src/alarm.html'),
+      },
+    },
+  },
 })
-
-
-// export default defineConfig({
-//   plugins: [crx({ manifest })],
-//   build: {
-//     rollupOptions: {
-//       output: {
-//         chunkFileNames: 'assets/[name]-[hash].js',
-//         entryFileNames: 'assets/[name]-[hash].js',
-//         assetFileNames: 'assets/[name]-[hash].[ext]'
-//       }
-//     }
-//   }
-// })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Alarm now opens a dedicated popup showing its name and description.
  - Adds Snooze (5 min) and Close actions.
  - Supports light/dark themes and centers the popup on screen.

- Changes
  - Replaces system notifications with an in-app popup experience.

- Style
  - Introduces a polished Alarm view layout and button styling.

- Chores
  - Updates permissions (adds display info, removes notifications).
  - Adds a new alarm page asset accessible to the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->